### PR TITLE
Add deprecated blocks support

### DIFF
--- a/blocks/build/build.js
+++ b/blocks/build/build.js
@@ -474,6 +474,112 @@ registerBlockType('rtgb/showcase', {
 		}
 	},
 
+	deprecated: [{
+		save: function save(props) {
+			var _props$attributes = props.attributes,
+			    showCaseImage = _props$attributes.showCaseImage,
+			    showCaseTitle = _props$attributes.showCaseTitle,
+			    showCaseContent = _props$attributes.showCaseContent,
+			    showCaseLink = _props$attributes.showCaseLink;
+
+
+			var className = props.className ? props.className : '';
+			var imageContent = '';
+
+			imageContent = wp.element.createElement(
+				'div',
+				{ className: 'image-container' },
+				wp.element.createElement(
+					'figure',
+					null,
+					wp.element.createElement('img', { src: showCaseImage.url, alt: showCaseImage.title })
+				)
+			);
+
+			return wp.element.createElement(
+				'div',
+				{ className: className + ' showcase-wrapper alignwide' },
+				imageContent,
+				wp.element.createElement(
+					'div',
+					{ className: 'info-container' },
+					showCaseLink ? wp.element.createElement(
+						'h3',
+						null,
+						wp.element.createElement(
+							'a',
+							{ href: showCaseLink, className: 'showcase-title' },
+							showCaseTitle
+						)
+					) : wp.element.createElement(
+						'h3',
+						{ className: 'showcase-title' },
+						showCaseTitle
+					),
+					wp.element.createElement(
+						'div',
+						{ className: 'showcase-content' },
+						showCaseContent
+					),
+					showCaseLink ? wp.element.createElement(
+						'a',
+						{
+							href: showCaseLink,
+							title: __('Read More'),
+							className: 'button secondary' },
+						__('Read More')
+					) : ''
+				)
+			);
+		},
+
+		attributes: {
+			showCaseTitle: {
+				type: 'array',
+				field: {
+					type: 'rich-text',
+					className: 'showcase-title',
+					placeholder: __('Showcase Title'),
+					tagName: 'h3'
+				},
+				selector: '.showcase-title',
+				source: 'children'
+			},
+
+			showCaseContent: {
+				type: 'array',
+				field: {
+					type: 'rich-text',
+					className: 'showcase-content',
+					placeholder: __('Showcase description'),
+					tagName: 'div',
+					multiline: 'p'
+				},
+				selector: '.showcase-content',
+				source: 'children'
+			},
+
+			showCaseImage: {
+				type: 'object',
+				field: {
+					type: 'image',
+					buttonText: __('Upload'),
+					imagePlaceholder: true,
+					removeButtonText: __('Remove')
+				}
+			},
+
+			showCaseLink: {
+				type: 'string',
+				field: {
+					type: 'link',
+					placement: 'inspector',
+					label: __('Showcase link')
+				}
+			}
+		}
+	}],
+
 	getEditWrapperProps: function getEditWrapperProps() {
 		return { 'data-align': 'wide' };
 	},
@@ -506,11 +612,11 @@ registerBlockType('rtgb/showcase', {
 		);
 	},
 	save: function save(props) {
-		var _props$attributes = props.attributes,
-		    showCaseImage = _props$attributes.showCaseImage,
-		    showCaseTitle = _props$attributes.showCaseTitle,
-		    showCaseContent = _props$attributes.showCaseContent,
-		    showCaseLink = _props$attributes.showCaseLink;
+		var _props$attributes2 = props.attributes,
+		    showCaseImage = _props$attributes2.showCaseImage,
+		    showCaseTitle = _props$attributes2.showCaseTitle,
+		    showCaseContent = _props$attributes2.showCaseContent,
+		    showCaseLink = _props$attributes2.showCaseLink;
 
 
 		var className = props.className ? props.className : '';

--- a/blocks/showcase/index.js
+++ b/blocks/showcase/index.js
@@ -64,6 +64,105 @@ registerBlockType( 'rtgb/showcase', {
 		},
 	},
 
+	deprecated: [
+		{
+			save( props ) {
+				const {
+					attributes: {
+						showCaseImage,
+						showCaseTitle,
+						showCaseContent,
+						showCaseLink,
+					},
+				} = props;
+
+				const className = props.className ? props.className : '';
+				let imageContent = '';
+
+				imageContent = (
+					<div className="image-container">
+						<figure>
+							<img src={ showCaseImage.url } alt={ showCaseImage.title } />
+						</figure>
+					</div>
+				);
+
+				return (
+					<div className={ className + ' showcase-wrapper alignwide' }>
+						{ imageContent }
+						<div className="info-container">
+							{ showCaseLink ? (
+								<h3>
+									<a href={ showCaseLink } className="showcase-title">
+										{ showCaseTitle }
+									</a>
+								</h3>
+							) : (
+								<h3 className="showcase-title">{ showCaseTitle }</h3>
+							) }
+							<div className="showcase-content">{ showCaseContent }</div>
+							{ showCaseLink ? (
+								<a
+									href={ showCaseLink }
+									title={ __( 'Read More' ) }
+									className="button secondary">
+									{ __( 'Read More' ) }
+								</a>
+							) : (
+								''
+							) }
+						</div>
+					</div>
+				);
+			},
+			attributes: {
+				showCaseTitle: {
+					type: 'array',
+					field: {
+						type: 'rich-text',
+						className: 'showcase-title',
+						placeholder: __( 'Showcase Title' ),
+						tagName: 'h3',
+					},
+					selector: '.showcase-title',
+					source: 'children',
+				},
+
+				showCaseContent: {
+					type: 'array',
+					field: {
+						type: 'rich-text',
+						className: 'showcase-content',
+						placeholder: __( 'Showcase description' ),
+						tagName: 'div',
+						multiline: 'p',
+					},
+					selector: '.showcase-content',
+					source: 'children',
+				},
+
+				showCaseImage: {
+					type: 'object',
+					field: {
+						type: 'image',
+						buttonText: __( 'Upload' ),
+						imagePlaceholder: true,
+						removeButtonText: __( 'Remove' ),
+					},
+				},
+
+				showCaseLink: {
+					type: 'string',
+					field: {
+						type: 'link',
+						placement: 'inspector',
+						label: __( 'Showcase link' ),
+					},
+				},
+			},
+		},
+	],
+
 	getEditWrapperProps() {
 		return { 'data-align': 'wide' };
 	},
@@ -72,7 +171,7 @@ registerBlockType( 'rtgb/showcase', {
 		const {
 			attributes: {
 				showCaseLink,
-			}
+			},
 		} = props;
 
 		const className = props.className ? props.className : '';


### PR DESCRIPTION
This PR deals with adding support for deprecated blocks. Because of that blocks are not visible in the backend.

<img width="1440" alt="Screenshot 2019-10-08 at 1 20 16 PM" src="https://user-images.githubusercontent.com/29889620/66377020-63e50900-e9ce-11e9-97cc-57dc4e040539.png">
